### PR TITLE
link against pthread when available

### DIFF
--- a/vendor/gtest-1.7.0/CMakeLists.txt
+++ b/vendor/gtest-1.7.0/CMakeLists.txt
@@ -1,8 +1,14 @@
 project(gtest CXX C)
 cmake_minimum_required(VERSION 2.6.2)
 
+find_package(Threads)
+
 include_directories(include)
 
 add_library(gtest src/gtest-all.cc)
+target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
+if(NOT WIN32)
+  set_target_properties(gtest PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
+endif()
 
 add_library(gtest_main src/gtest_main.cc)


### PR DESCRIPTION
Fixes ament/ament_index#8.

http://ci.ros2.org/job/ros2_batch_ci_linux/538/ (using ros2/ros2#138 to not have the `libgtest-dev` Debian package installed)
http://ci.ros2.org/job/ros2_batch_ci_osx/408/
http://ci.ros2.org/job/ros2_batch_ci_windows/562/
