### PR TITLE
Force static linking instead of honoring BUILD_SHARED_LIBS

### DIFF
--- a/vendor/gtest-1.7.0/CMakeLists.txt
+++ b/vendor/gtest-1.7.0/CMakeLists.txt
@@ -5,10 +5,10 @@ find_package(Threads)
 
 include_directories(include)
 
-add_library(gtest src/gtest-all.cc)
+add_library(gtest STATIC src/gtest-all.cc)
 target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
 if(NOT WIN32)
   set_target_properties(gtest PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
 endif()
 
-add_library(gtest_main src/gtest_main.cc)
+add_library(gtest_main STATIC src/gtest_main.cc)


### PR DESCRIPTION
Force static linking instead of honoring BUILD_SHARED_LIBS

See https://github.com/ros2/rmw/pull/81#issuecomment-291997813

Connects to ros2/ros2#306