### PR TITLE
Add build tool dependency on cmake.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,11 @@
   <description>The package provides GoogleTest.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>
-
+  
+  <build_depend>cmake</build_depend>
+  
+  <build_export_depend>cmake</build_export_depend>
+  
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -9,8 +9,6 @@
   
   <build_depend>cmake</build_depend>
   
-  <build_export_depend>cmake</build_export_depend>
-  
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -6,9 +6,9 @@
   <description>The package provides GoogleTest.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>
-  
+
   <build_depend>cmake</build_depend>
-  
+
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
Analog of https://github.com/ament/gmock_vendor/pull/4 for gtest_vendor.